### PR TITLE
Fix manually added service_account_credentials.json

### DIFF
--- a/DependencyInjection/Factory/ProjectFactory.php
+++ b/DependencyInjection/Factory/ProjectFactory.php
@@ -29,7 +29,7 @@ class ProjectFactory
         }
 
         if ($config['database_uri'] ?? null) {
-            $factory = $this->firebaseFactory->withDatabaseUri($config['database_uri']);
+            $factory = $factory->withDatabaseUri($config['database_uri']);
         }
 
         return $factory->create();


### PR DESCRIPTION
Fix service account credentials file auto discover when credentials path configured.

> credentials: '%kernel.project_dir%/src/AppBundle/Resources/config/service_account_credentials.json'

```
Kreait\Firebase\ServiceAccount\Discovery\FromEnvironmentVariable: The environment variable "FIREBASE_CREDENTIALS" is not set.
Kreait\Firebase\ServiceAccount\Discovery\FromEnvironmentVariable: The environment variable "GOOGLE_APPLICATION_CREDENTIALS" is not set.
Kreait\Firebase\ServiceAccount\Discovery\FromGoogleWellKnownFile: The well known file is not readable or invalid
```