### PR TITLE
Fix deprecated root node

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -22,8 +22,13 @@ class Configuration implements ConfigurationInterface
 
     public function getConfigTreeBuilder()
     {
-        $builder = new TreeBuilder();
-        $root = $builder->root($this->name);
+        $builder = new TreeBuilder($this->name);
+
+        if (method_exists($builder, 'getRootNode')) {
+            $root = $builder->getRootNode();
+        } else {
+            $root = $builder->root($this->name);
+        }
 
         $root
             ->fixXmlConfig('project')


### PR DESCRIPTION
Fix "tree builder without a root node" deprecation in Symfony 4.2+

Context:
https://symfony.com/blog/new-in-symfony-4-2-important-deprecations