### PR TITLE
Easier auto-wire when using multiple projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,16 @@ The following classes will be available for dependency injection if you have con
 * `Kreait\Firebase\Contract\Storage`
 * `Kreait\Firebase\Contract\DynamicLinks`
 
+To make it easier to use classes via dependency injection in the constructor of a class when multiple projects exist, you can do this in the constructor:
+
+* `Kreait\Firebase\Contract\Auth $my_projectAuth`
+* `Kreait\Firebase\Contract\Database $my_projectDatabase`
+* `Kreait\Firebase\Contract\Firestore $my_projectFirestore`
+* `Kreait\Firebase\Contract\Messaging $my_projectMessaging`
+* `Kreait\Firebase\Contract\RemoteConfig $my_projectRemoteConfig`
+* `Kreait\Firebase\Contract\Storage $my_projectStorage`
+* `Kreait\Firebase\Contract\DynamicLinks $my_projectDynamicLinks`
+
 ### Full
 
 ```yaml

--- a/src/DependencyInjection/FirebaseExtension.php
+++ b/src/DependencyInjection/FirebaseExtension.php
@@ -40,13 +40,13 @@ class FirebaseExtension extends Extension
 
     private function processProjectConfiguration(string $name, array $config, ContainerBuilder $container): void
     {
-        $this->registerService($name.'.database', $config, Firebase\Contract\Database::class, $container, 'createDatabase');
-        $this->registerService($name.'.auth', $config, Firebase\Contract\Auth::class, $container, 'createAuth');
-        $this->registerService($name.'.storage', $config, Firebase\Contract\Storage::class, $container, 'createStorage');
-        $this->registerService($name.'.remote_config', $config, Firebase\Contract\RemoteConfig::class, $container, 'createRemoteConfig');
-        $this->registerService($name.'.messaging', $config, Firebase\Contract\Messaging::class, $container, 'createMessaging');
-        $this->registerService($name.'.firestore', $config, Firebase\Contract\Firestore::class, $container, 'createFirestore');
-        $this->registerService($name.'.dynamic_links', $config, Firebase\Contract\DynamicLinks::class, $container, 'createDynamicLinksService');
+        $this->registerService($name, 'database', $config, Firebase\Contract\Database::class, $container, 'createDatabase');
+        $this->registerService($name, 'auth', $config, Firebase\Contract\Auth::class, $container, 'createAuth');
+        $this->registerService($name, 'storage', $config, Firebase\Contract\Storage::class, $container, 'createStorage');
+        $this->registerService($name, 'remote_config', $config, Firebase\Contract\RemoteConfig::class, $container, 'createRemoteConfig');
+        $this->registerService($name, 'messaging', $config, Firebase\Contract\Messaging::class, $container, 'createMessaging');
+        $this->registerService($name, 'firestore', $config, Firebase\Contract\Firestore::class, $container, 'createFirestore');
+        $this->registerService($name, 'dynamic_links', $config, Firebase\Contract\DynamicLinks::class, $container, 'createDynamicLinksService');
     }
 
     public function getAlias(): string
@@ -59,9 +59,9 @@ class FirebaseExtension extends Extension
         return new Configuration($this->getAlias());
     }
 
-    private function registerService(string $name, array $config, string $contract, ContainerBuilder $container, string $method = 'create'): void
+    private function registerService(string $name, string $postfix, array $config, string $contract, ContainerBuilder $container, string $method = 'create'): void
     {
-        $projectServiceId = \sprintf('%s.%s', $this->getAlias(), $name);
+        $projectServiceId = \sprintf('%s.%s.%s', $this->getAlias(), $name, $postfix);
         $isPublic = $config['public'];
 
         $factory = new Definition(ProjectFactory::class);
@@ -91,6 +91,8 @@ class FirebaseExtension extends Extension
         if ($config['default'] ?? false) {
             $container->setAlias($contract, $projectServiceId)->setPublic($isPublic);
         }
+
+        $container->registerAliasForArgument($projectServiceId, $contract, $name.ucfirst($postfix));
     }
 
     private function assertThatOnlyOneDefaultProjectExists(array $projectConfigurations): void

--- a/tests/DependencyInjection/FirebaseExtensionTest.php
+++ b/tests/DependencyInjection/FirebaseExtensionTest.php
@@ -45,21 +45,27 @@ final class FirebaseExtensionTest extends TestCase
 
         $this->assertInstanceOf(Firebase\Contract\Database::class, $container->get($this->extension->getAlias().'.foo.database'));
         $this->assertInstanceOf(Firebase\Contract\Database::class, $container->get(Firebase\Contract\Database::class));
+        $this->assertInstanceOf(Firebase\Contract\Database::class, $container->get(Firebase\Contract\Database::class.' $fooDatabase'));
 
         $this->assertInstanceOf(Firebase\Contract\Auth::class, $container->get($this->extension->getAlias().'.foo.auth'));
         $this->assertInstanceOf(Firebase\Contract\Auth::class, $container->get(Firebase\Contract\Auth::class));
+        $this->assertInstanceOf(Firebase\Contract\Auth::class, $container->get(Firebase\Contract\Auth::class.' $fooAuth'));
 
         $this->assertInstanceOf(Firebase\Contract\Storage::class, $container->get($this->extension->getAlias().'.foo.storage'));
         $this->assertInstanceOf(Firebase\Contract\Storage::class, $container->get(Firebase\Contract\Storage::class));
+        $this->assertInstanceOf(Firebase\Contract\Storage::class, $container->get(Firebase\Contract\Storage::class.' $fooStorage'));
 
         $this->assertInstanceOf(Firebase\Contract\RemoteConfig::class, $container->get($this->extension->getAlias().'.foo.remote_config'));
         $this->assertInstanceOf(Firebase\Contract\RemoteConfig::class, $container->get(Firebase\Contract\RemoteConfig::class));
+        $this->assertInstanceOf(Firebase\Contract\RemoteConfig::class, $container->get(Firebase\Contract\RemoteConfig::class.' $fooRemoteConfig'));
 
         $this->assertInstanceOf(Firebase\Contract\Messaging::class, $container->get($this->extension->getAlias().'.foo.messaging'));
         $this->assertInstanceOf(Firebase\Contract\Messaging::class, $container->get(Firebase\Contract\Messaging::class));
+        $this->assertInstanceOf(Firebase\Contract\Messaging::class, $container->get(Firebase\Contract\Messaging::class.' $fooMessaging'));
 
         $this->assertInstanceOf(Firebase\Contract\DynamicLinks::class, $container->get($this->extension->getAlias().'.foo.dynamic_links'));
         $this->assertInstanceOf(Firebase\Contract\DynamicLinks::class, $container->get(Firebase\Contract\DynamicLinks::class));
+        $this->assertInstanceOf(Firebase\Contract\DynamicLinks::class, $container->get(Firebase\Contract\DynamicLinks::class.' $fooDynamicLinks'));
     }
 
     /**


### PR DESCRIPTION
In our application, we use multiple projects. To be able to autowire messaging-services, we now have to use aliases and interfaces. This PR creates extra aliases the same way as https://symfony.com/doc/current/logging/channels_handlers.html#how-to-autowire-logger-channels so we can use constructors like this:

```php
public function __construct(
    private Messaging $project1Messaging,
    private Messaging $project2Messaging,
) {
}
```
