### PR TITLE
Make services lazy

### DIFF
--- a/src/DependencyInjection/Factory/ProjectFactory.php
+++ b/src/DependencyInjection/Factory/ProjectFactory.php
@@ -13,16 +13,10 @@ use Symfony\Component\Cache\Adapter\Psr16Adapter;
 
 class ProjectFactory
 {
-    private Factory $firebaseFactory;
     private ?CacheItemPoolInterface $verifierCache = null;
     private ?CacheItemPoolInterface $authTokenCache = null;
     private ?LoggerInterface $httpRequestLogger = null;
     private ?LoggerInterface $httpRequestDebugLogger = null;
-
-    public function __construct()
-    {
-        $this->firebaseFactory = new Factory();
-    }
 
     /**
      * @param CacheInterface|CacheItemPoolInterface $verifierCache
@@ -65,7 +59,7 @@ class ProjectFactory
 
     public function createFactory(array $config = []): Factory
     {
-        $factory = clone $this->firebaseFactory; // Ensure a new instance
+        $factory = new Factory();
 
         if ($config['credentials'] ?? null) {
             $factory = $factory->withServiceAccount($config['credentials']);

--- a/src/DependencyInjection/FirebaseExtension.php
+++ b/src/DependencyInjection/FirebaseExtension.php
@@ -85,6 +85,7 @@ class FirebaseExtension extends Extension
 
         $container->register($projectServiceId, $contract)
             ->setFactory([$factory, $method])
+            ->setLazy(true)
             ->addArgument($config)
             ->setPublic($isPublic);
 

--- a/src/Resources/config/firebase.xml
+++ b/src/Resources/config/firebase.xml
@@ -11,9 +11,7 @@
     <services>
         <service id="Kreait\Firebase\Factory" class="%kreait.firebase.factory%" />
 
-        <service id="Kreait\Firebase\Symfony\Bundle\DependencyInjection\Factory\ProjectFactory" class="%kreait.firebase.bundle.project_factory%" public="false">
-            <argument type="service" id="Kreait\Firebase\Factory" />
-        </service>
+        <service id="Kreait\Firebase\Symfony\Bundle\DependencyInjection\Factory\ProjectFactory" class="%kreait.firebase.bundle.project_factory%" public="false" />
     </services>
 
 </container>

--- a/tests/DependencyInjection/FirebaseExtensionTest.php
+++ b/tests/DependencyInjection/FirebaseExtensionTest.php
@@ -179,7 +179,9 @@ final class FirebaseExtensionTest extends TestCase
         $container->set($cacheServiceId, $invalidCache);
 
         $this->expectException(TypeError::class);
-        $container->get(Firebase\Contract\Auth::class);
+        /** @var Firebase\Contract\Auth $service */
+        $service = $container->get(Firebase\Contract\Auth::class);
+        $service->createAnonymousUser();
     }
 
     /**
@@ -199,7 +201,9 @@ final class FirebaseExtensionTest extends TestCase
         ]);
 
         $this->expectException(ServiceNotFoundException::class);
-        $container->get(Firebase\Contract\Auth::class);
+        /** @var Firebase\Contract\Auth $service */
+        $service = $container->get(Firebase\Contract\Auth::class);
+        $service->createAnonymousUser();
     }
 
     /**


### PR DESCRIPTION

# Description

Some compute are done when services are instantiated (e.g. injected). Better to compute only if the service is really used.

Why did I do that? Multiple reasons:
- Optimize the services creation, less compute if not needed
- Fix cases when you when your app to work (`composer install`, page rendering, etc...) without having a `credentials.json`
- Do not change how most of the bundle works

Plus some optimizations:
- `ProjectFactory` service do not need `Factory` factory injection (no argument in its constructor).
- `ProjectFactory::createFactory` if we really want a new instance, use `new` instead of `clone` to ensure it.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works _(only update 2 tests to load lazy service)_
- [x] I have made corresponding changes to the documentation _(does not need any change)_
