### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
         "symfony/cache": "^5.4 || ^6.0 || ^7.0",
         "symfony/config": "^5.4 || ^6.0 || ^7.0",
         "symfony/dependency-injection": "^5.4 || ^6.0 || ^7.0",
-        "symfony/http-kernel": "^5.4 || ^6.0 || ^7.0"
+        "symfony/http-kernel": "^5.4 || ^6.0 || ^7.0",
+        "symfony/polyfill-php82": "^1.33",
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5.10"
@@ -36,6 +37,7 @@
     "config": {
         "sort-packages": true
     },
+    
     "funding": [
         {
             "type": "github",


### PR DESCRIPTION
# Description

Adds symfony/polyfill-php82, which provides a userland implementation of PHP 8.2 features such as the \SensitiveParameter attribute for runtimes below 8.2.

On PHP 8.1, \SensitiveParameter does not exist natively, so code referencing it will throw a reflection error. The polyfill defines it to ensure compatibility with libraries (like kreait/firebase-php) that use the attribute.

# Checklist:

- [ X ] My code follows the style guidelines of this project
- [ X ] I have performed a self-review of my own code
- [  ] I have added tests that prove my fix is effective or that my feature works
- [  ] I have made corresponding changes to the documentation
